### PR TITLE
Fix package.json exports field for proper TypeScript type resolution

### DIFF
--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -1,0 +1,37 @@
+name: Package Validation
+
+on:
+  push:
+    branches: [main, release/**]
+  pull_request:
+    branches: [main, release/**]
+
+jobs:
+  validate-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10
+          run_install: false
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Run publint
+        run: npx publint
+
+      - name: Run arethetypeswrong
+        run: npx @arethetypeswrong/cli . --pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Validate
         run: pnpm validate
 
+      - name: Validate Package Structure
+        run: pnpm validate:package
+
       - name: Build
         run: pnpm build
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,6 +12,7 @@ This document provides guidelines and instructions for contributors to the OpenB
 ### Setup
 
 1. Clone the repository:
+
    ```bash
    git clone https://github.com/rollercoaster-dev/openbadges-types.git
    cd openbadges-types
@@ -93,6 +94,21 @@ To validate the codebase (lint, format check, and test):
 ```bash
 pnpm validate
 ```
+
+### Package Structure Validation
+
+To validate the package structure and ensure it's compatible with both CommonJS and ESM:
+
+```bash
+pnpm validate:package
+```
+
+This runs:
+
+1. `publint` - Validates package.json exports and entry points
+2. `@arethetypeswrong/cli` - Checks for TypeScript type resolution issues
+
+These tools are also integrated into the CI pipeline to ensure the package structure remains correct.
 
 ## Project Structure
 
@@ -185,6 +201,7 @@ This project follows the [Conventional Commits](https://www.conventionalcommits.
 ```
 
 Types include:
+
 - `feat`: A new feature
 - `fix`: A bug fix
 - `docs`: Documentation only changes
@@ -200,6 +217,7 @@ If you're a maintainer:
 
 1. Ensure all tests pass and the build is successful
 2. Run one of the following commands based on the type of release:
+
    ```bash
    # Automatic version bump based on commit messages
    npm run release
@@ -213,6 +231,7 @@ If you're a maintainer:
    npm run release:alpha  # Alpha release
    npm run release:beta   # Beta release
    ```
+
 3. Push the changes and tags to GitHub:
    ```bash
    git push --follow-tags origin main

--- a/README.md
+++ b/README.md
@@ -414,6 +414,39 @@ console.log(OB3_CONTEXT['@context']);
 
 For detailed development instructions, see [DEVELOPMENT.md](DEVELOPMENT.md).
 
+### Package Structure
+
+This package is built to support both CommonJS and ESM environments, with proper TypeScript type definitions for each format:
+
+```json
+{
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "default": "./dist/index.js"
+    }
+  }
+}
+```
+
+This structure ensures:
+
+- CommonJS consumers get the correct `.cjs` file with `.d.cts` type definitions
+- ESM consumers get the correct `.js` file with `.d.ts` type definitions
+- TypeScript can properly resolve types in both module formats
+
+The package is validated using:
+
+- `publint` - Validates package.json exports and entry points
+- `@arethetypeswrong/cli` - Checks for TypeScript type resolution issues
+
 ### Testing
 
 This package uses Jest for testing. The tests verify that the type definitions correctly match the OpenBadges 2.0 and 3.0 specifications.

--- a/package.json
+++ b/package.json
@@ -4,11 +4,18 @@
   "type": "module",
   "description": "TypeScript type definitions for Open Badges 2.0 and 3.0 specifications",
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/index.js",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "default": "./dist/index.js"
     }
   },
   "types": "dist/index.d.ts",
@@ -26,7 +33,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "validate": "pnpm lint && pnpm format:check && pnpm test",
+    "validate": "pnpm lint && pnpm format:check && pnpm test && pnpm validate:package",
+    "validate:package": "pnpm build && npx publint && npx @arethetypeswrong/cli . --pack",
     "prepare": "husky",
     "dev": "tsc --watch",
     "prepublishOnly": "pnpm validate && pnpm build",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,4 +7,10 @@ export default defineConfig({
   format: ['cjs', 'esm'],
   sourcemap: true,
   outDir: 'dist',
+  outExtension({ format }) {
+    return {
+      js: format === 'cjs' ? '.cjs' : '.js',
+      dts: format === 'cjs' ? '.d.cts' : '.d.ts',
+    };
+  },
 });


### PR DESCRIPTION
## Changes

This PR fixes the package.json exports field to properly support both CommonJS and ESM environments with correct TypeScript type definitions.

### Key Improvements

1. **Fixed Package Structure**:
   - Updated the `exports` field in `package.json` to properly support both CommonJS and ESM
   - Added format-specific type definitions for better TypeScript compatibility
   - Updated the tsup configuration to generate the correct file extensions

2. **Added Package Validation**:
   - Added `validate:package` script that runs both `publint` and `@arethetypeswrong/cli`
   - Added this validation to the existing `validate` script

3. **Added CI Integration**:
   - Created a new GitHub Actions workflow file (`package-validation.yml`) to validate the package structure
   - Updated the release workflow to include package validation

4. **Updated Documentation**:
   - Added information about the package structure to the README.md
   - Added details about package validation to the DEVELOPMENT.md

### Benefits

- Improved compatibility with both CommonJS and ESM environments
- Better developer experience with proper type resolution in both module formats
- Automated validation to prevent package structure regressions
- Better documentation for contributors

### Testing

The changes have been tested with:
- `publint` - Validates package.json exports and entry points
- `@arethetypeswrong/cli` - Checks for TypeScript type resolution issues

Both tools report no issues with the updated package structure.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author