### PR TITLE
fix: resolve circular dependencies in imports

### DIFF
--- a/src/composite-guards.ts
+++ b/src/composite-guards.ts
@@ -1,4 +1,5 @@
-import { OB2, OB3 } from './index';
+import * as OB2 from './v2/index';
+import * as OB3 from './v3/index';
 
 /**
  * Type representing either an OB2 Assertion or OB3 VerifiableCredential

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,9 @@ import * as OB2 from './v2/index';
 import * as OB3 from './v3/index';
 import * as CompositeGuards from './composite-guards';
 import * as BadgeNormalizer from './badge-normalizer';
+import { Badge } from './composite-guards';
 
-export { Shared, OB2, OB3, CompositeGuards, BadgeNormalizer };
+export { Shared, OB2, OB3, CompositeGuards, BadgeNormalizer, Badge };
 export * from './validation';
 export * from './type-guards';
 export * from './utils';

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,4 +1,6 @@
-import { OB2, OB3, Shared } from './index';
+import * as OB2 from './v2/index';
+import * as OB3 from './v3/index';
+import * as Shared from './shared/index';
 
 /**
  * Result of a badge validation


### PR DESCRIPTION
Change imports in src/composite-guards.ts and src/validation.ts to point directly to v2/v3/shared indices instead of the main src/index.ts.

This resolves circular dependency issues that prevented the module from being correctly resolved.

## Pull Request Checklist

- [ ] My commits use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have updated or checked the `CHANGELOG.md` for this change
- [ ] I have checked that all type and protocol changes are documented
- [ ] I have run all tests and linters (`pnpm validate`)
- [ ] I have updated documentation if needed (README, MIGRATION.md, protocol-compliance, etc.)
- [ ] This PR is ready for review

### Description of Change

<!-- Please describe your change, why it was needed, and any migration or review notes. --> 