### PR TITLE
fix: improve OB3 validation for nested objects and array types

### DIFF
--- a/PR_README.md
+++ b/PR_README.md
@@ -1,0 +1,44 @@
+# Fix OB3 Validation for Nested Objects
+
+## Problem
+
+The current implementation of the OB3 type guards has limitations when validating nested objects:
+
+1. **Nested objects without `@context`**: The `isJsonLdObject` function requires both `@context` and `type` properties to be present, which causes validation to fail for nested objects like `issuer` and `achievement` that don't typically include the `@context` property when embedded in a parent object.
+
+2. **Array types handling**: The validation functions don't properly handle both string and array types for the `type` field, despite the interfaces allowing both formats.
+
+This causes validation to fail for valid OB3 badges that:
+- Have nested objects without `@context` properties
+- Use array types (e.g., `type: ['Profile']` instead of `type: 'Profile'`)
+
+## Solution
+
+This PR modifies the type guards for nested objects to be more flexible:
+
+1. For the `isIssuer` function:
+   - Removed the dependency on `isJsonLdObject`
+   - Check for required properties directly (id, name, url)
+   - Handle both string and array types for the `type` property
+
+2. For the `isAchievement` function:
+   - Removed the dependency on `isJsonLdObject`
+   - Check for required properties directly (id, name)
+   - Handle both string and array types for the `type` property
+
+## Changes
+
+- Modified `isIssuer` function in `src/v3/guards.ts`
+- Modified `isAchievement` function in `src/v3/guards.ts`
+- Added tests in `test/ob3-nested-validation.test.ts` to verify the behavior
+
+## Testing
+
+The new tests verify that:
+1. Badges with nested objects that include `@context` properties validate correctly
+2. Badges with nested objects that don't include `@context` properties now validate correctly
+3. Badges with array types for the `type` field now validate correctly
+
+## Impact
+
+This change makes the package more robust when dealing with real-world OB3 badges, which often have nested objects without `@context` properties and may use array types for the `type` field.

--- a/src/v3/guards.ts
+++ b/src/v3/guards.ts
@@ -53,20 +53,26 @@ export function isVerifiableCredential(value: unknown): value is VerifiableCrede
  * @returns True if the value is a valid OB3 Issuer, false otherwise
  */
 export function isIssuer(value: unknown): value is Issuer {
-  if (!isJsonLdObject(value)) {
+  if (typeof value !== 'object' || value === null) {
     return false;
   }
 
   // Check for required properties
-  if (!('id' in value) || !('name' in value)) {
+  if (!('id' in value) || !('name' in value) || !('url' in value)) {
     return false;
   }
 
-  // Check for Profile type
-  if (!hasJsonLdType(value, 'Profile')) {
-    return false;
+  // If it has a type property, check if it's 'Profile'
+  if ('type' in value) {
+    const type = value.type;
+    if (Array.isArray(type)) {
+      return type.includes('Profile');
+    } else if (typeof type === 'string') {
+      return type === 'Profile';
+    }
   }
 
+  // If no type property or type check failed, still consider it valid if it has the required fields
   return true;
 }
 
@@ -115,12 +121,7 @@ export function isCredentialSubject(value: unknown): value is CredentialSubject 
  * @returns True if the value is a valid OB3 Achievement, false otherwise
  */
 export function isAchievement(value: unknown): value is Achievement {
-  if (!isJsonLdObject(value)) {
-    return false;
-  }
-
-  // Check for Achievement type
-  if (!hasJsonLdType(value, 'Achievement')) {
+  if (typeof value !== 'object' || value === null) {
     return false;
   }
 
@@ -129,6 +130,17 @@ export function isAchievement(value: unknown): value is Achievement {
     return false;
   }
 
+  // If it has a type property, check if it's 'Achievement'
+  if ('type' in value) {
+    const type = value.type;
+    if (Array.isArray(type)) {
+      return type.includes('Achievement');
+    } else if (typeof type === 'string') {
+      return type === 'Achievement';
+    }
+  }
+
+  // If no type property or type check failed, still consider it valid if it has the required fields
   return true;
 }
 

--- a/src/v3/guards.ts
+++ b/src/v3/guards.ts
@@ -65,10 +65,17 @@ export function isIssuer(value: unknown): value is Issuer {
   // If it has a type property, check if it's 'Profile'
   if ('type' in value) {
     const type = value.type;
+    // Ensure 'type' is either a string or an array of strings
     if (Array.isArray(type)) {
-      return type.includes('Profile');
+      if (type.every(item => typeof item === 'string')) {
+        return type.includes('Profile');
+      } else {
+        return false; // Invalid array contents
+      }
     } else if (typeof type === 'string') {
       return type === 'Profile';
+    } else {
+      return false; // Unexpected type
     }
   }
 
@@ -133,10 +140,17 @@ export function isAchievement(value: unknown): value is Achievement {
   // If it has a type property, check if it's 'Achievement'
   if ('type' in value) {
     const type = value.type;
+    // Ensure 'type' is either a string or an array of strings
     if (Array.isArray(type)) {
-      return type.includes('Achievement');
+      if (type.every(item => typeof item === 'string')) {
+        return type.includes('Achievement');
+      } else {
+        return false; // Invalid array contents
+      }
     } else if (typeof type === 'string') {
       return type === 'Achievement';
+    } else {
+      return false; // Unexpected type
     }
   }
 

--- a/test/ob3-nested-validation.test.ts
+++ b/test/ob3-nested-validation.test.ts
@@ -101,6 +101,38 @@ describe('OB3 Nested Object Validation', () => {
     },
   };
 
+  // Test data - an OB3 badge with invalid array types
+  const invalidArrayTypesOB3Badge = {
+    '@context': [
+      'https://www.w3.org/2018/credentials/v1',
+      'https://purl.imsglobal.org/spec/ob/v3p0/context.json',
+    ],
+    id: 'https://example.org/credentials/3732',
+    type: ['VerifiableCredential'],
+    issuer: {
+      id: 'https://example.org/issuers/123',
+      type: [123, 456], // Invalid array contents (numbers instead of strings)
+      name: 'Example Maker Society',
+      url: 'https://example.org',
+      email: 'contact@example.org',
+    },
+    issuanceDate: '2023-06-15T12:00:00Z',
+    credentialSubject: {
+      id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+      achievement: {
+        id: 'https://example.org/achievements/1',
+        type: { key: 'value' }, // Invalid type (object instead of string or array)
+        name: '3-D Printmaster',
+        description:
+          'This badge is awarded for passing the 3-D printing knowledge and safety test.',
+        criteria: {
+          narrative:
+            'Students are tested on knowledge and safety, both through a paper test and a supervised performance evaluation on key skills.',
+        },
+      },
+    },
+  };
+
   describe('Validation Behavior', () => {
     test('should validate a complete OB3 badge with @context in nested objects', () => {
       const result = validateBadge(completeOB3Badge);
@@ -122,6 +154,14 @@ describe('OB3 Nested Object Validation', () => {
       // With our fix, validation should pass
       expect(result.isValid).toBe(true);
       expect(result.errors).toHaveLength(0);
+    });
+
+    test('should reject OB3 badge with invalid array types', () => {
+      const result = validateBadge(invalidArrayTypesOB3Badge);
+
+      // Should fail validation due to invalid types
+      expect(result.isValid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
     });
   });
 });

--- a/test/ob3-nested-validation.test.ts
+++ b/test/ob3-nested-validation.test.ts
@@ -1,0 +1,127 @@
+import { validateBadge } from '../src';
+
+describe('OB3 Nested Object Validation', () => {
+  // Test data - a complete OB3 badge with nested objects
+  const completeOB3Badge = {
+    '@context': [
+      'https://www.w3.org/2018/credentials/v1',
+      'https://purl.imsglobal.org/spec/ob/v3p0/context.json',
+    ],
+    id: 'https://example.org/credentials/3732',
+    type: 'VerifiableCredential',
+    issuer: {
+      '@context': 'https://purl.imsglobal.org/spec/ob/v3p0/context.json',
+      id: 'https://example.org/issuers/123',
+      type: 'Profile',
+      name: 'Example Maker Society',
+      url: 'https://example.org',
+      email: 'contact@example.org',
+    },
+    issuanceDate: '2023-06-15T12:00:00Z',
+    credentialSubject: {
+      id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+      achievement: {
+        '@context': 'https://purl.imsglobal.org/spec/ob/v3p0/context.json',
+        id: 'https://example.org/achievements/1',
+        type: 'Achievement',
+        name: '3-D Printmaster',
+        description:
+          'This badge is awarded for passing the 3-D printing knowledge and safety test.',
+        criteria: {
+          narrative:
+            'Students are tested on knowledge and safety, both through a paper test and a supervised performance evaluation on key skills.',
+        },
+      },
+    },
+  };
+
+  // Test data - an OB3 badge with nested objects missing @context
+  const nestedOB3Badge = {
+    '@context': [
+      'https://www.w3.org/2018/credentials/v1',
+      'https://purl.imsglobal.org/spec/ob/v3p0/context.json',
+    ],
+    id: 'https://example.org/credentials/3732',
+    type: 'VerifiableCredential',
+    issuer: {
+      // No @context property
+      id: 'https://example.org/issuers/123',
+      type: 'Profile',
+      name: 'Example Maker Society',
+      url: 'https://example.org',
+      email: 'contact@example.org',
+    },
+    issuanceDate: '2023-06-15T12:00:00Z',
+    credentialSubject: {
+      id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+      achievement: {
+        // No @context property
+        id: 'https://example.org/achievements/1',
+        type: 'Achievement',
+        name: '3-D Printmaster',
+        description:
+          'This badge is awarded for passing the 3-D printing knowledge and safety test.',
+        criteria: {
+          narrative:
+            'Students are tested on knowledge and safety, both through a paper test and a supervised performance evaluation on key skills.',
+        },
+      },
+    },
+  };
+
+  // Test data - an OB3 badge with array types
+  const arrayTypesOB3Badge = {
+    '@context': [
+      'https://www.w3.org/2018/credentials/v1',
+      'https://purl.imsglobal.org/spec/ob/v3p0/context.json',
+    ],
+    id: 'https://example.org/credentials/3732',
+    type: ['VerifiableCredential'],
+    issuer: {
+      id: 'https://example.org/issuers/123',
+      type: ['Profile'],
+      name: 'Example Maker Society',
+      url: 'https://example.org',
+      email: 'contact@example.org',
+    },
+    issuanceDate: '2023-06-15T12:00:00Z',
+    credentialSubject: {
+      id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+      achievement: {
+        id: 'https://example.org/achievements/1',
+        type: ['Achievement'],
+        name: '3-D Printmaster',
+        description:
+          'This badge is awarded for passing the 3-D printing knowledge and safety test.',
+        criteria: {
+          narrative:
+            'Students are tested on knowledge and safety, both through a paper test and a supervised performance evaluation on key skills.',
+        },
+      },
+    },
+  };
+
+  describe('Validation Behavior', () => {
+    test('should validate a complete OB3 badge with @context in nested objects', () => {
+      const result = validateBadge(completeOB3Badge);
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test('should validate OB3 badge with nested objects missing @context', () => {
+      const result = validateBadge(nestedOB3Badge);
+
+      // With our fix, validation should pass
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test('should validate OB3 badge with array types', () => {
+      const result = validateBadge(arrayTypesOB3Badge);
+
+      // With our fix, validation should pass
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The current implementation of the OB3 type guards has limitations when validating nested objects:

1. **Nested objects without `@context`**: The `isJsonLdObject` function requires both `@context` and `type` properties to be present, which causes validation to fail for nested objects like `issuer` and `achievement` that don't typically include the `@context` property when embedded in a parent object.

2. **Array types handling**: The validation functions don't properly handle both string and array types for the `type` field, despite the interfaces allowing both formats.

3. **Unexpected type values**: The validation functions don't properly handle unexpected type values, such as non-string array elements or objects instead of strings/arrays.

This causes validation to fail for valid OB3 badges that:
- Have nested objects without `@context` properties
- Use array types (e.g., `type: ['Profile']` instead of `type: 'Profile'`)

## Solution

This PR modifies the type guards for nested objects to be more flexible:

1. For the `isIssuer` function:
   - Removed the dependency on `isJsonLdObject`
   - Check for required properties directly (id, name, url)
   - Handle both string and array types for the `type` property
   - Explicitly handle unexpected type values

2. For the `isAchievement` function:
   - Removed the dependency on `isJsonLdObject`
   - Check for required properties directly (id, name)
   - Handle both string and array types for the `type` property
   - Explicitly handle unexpected type values

## Changes

- Modified `isIssuer` function in `src/v3/guards.ts`
- Modified `isAchievement` function in `src/v3/guards.ts`
- Added tests in `test/ob3-nested-validation.test.ts` to verify the behavior
- Added tests for invalid array types and unexpected type values

## Testing

The new tests verify that:
1. Badges with nested objects that include `@context` properties validate correctly
2. Badges with nested objects that don't include `@context` properties now validate correctly
3. Badges with array types for the `type` field now validate correctly
4. Badges with invalid array types (non-string elements) are rejected
5. Badges with unexpected type values (objects instead of strings/arrays) are rejected

## Impact

This change makes the package more robust when dealing with real-world OB3 badges, which often have nested objects without `@context` properties and may use array types for the `type` field.